### PR TITLE
Better exception if unreal date/ts

### DIFF
--- a/macros/dbt_utils/cross_db_utils/dateadd.sql
+++ b/macros/dbt_utils/cross_db_utils/dateadd.sql
@@ -1,8 +1,9 @@
 {% macro spark__dateadd(datepart, interval, from_date_or_timestamp) %}
 
     {%- set clock_component -%}
-        to_unix_timestamp(to_timestamp({{from_date_or_timestamp}}))
-        - to_unix_timestamp(date({{from_date_or_timestamp}}))
+        {# make sure the dates + timestamps are real, otherwise raise an error asap #}
+        to_unix_timestamp({{ spark_utils.assert_not_null('to_timestamp', from_date_or_timestamp) }})
+        - to_unix_timestamp({{ spark_utils.assert_not_null('date', from_date_or_timestamp) }})
     {%- endset -%}
 
     {%- if datepart in ['day', 'week'] -%}
@@ -11,7 +12,7 @@
 
         to_timestamp(
             to_unix_timestamp(
-                date_add(date({{from_date_or_timestamp}}), {{interval}} * {{multiplier}})
+                date_add({{ spark_utils.assert_not_null('date', from_date_or_timestamp) }}, {{interval}} * {{multiplier}})
             ) + {{clock_component}}
         )
 
@@ -26,7 +27,10 @@
 
         to_timestamp(
             to_unix_timestamp(
-                add_months(date({{from_date_or_timestamp}}), {{interval}} * {{multiplier}})
+                add_months(
+                    {{ spark_utils.assert_not_null('date', from_date_or_timestamp) }},
+                    {{interval}} * {{multiplier}}
+                )
             ) + {{clock_component}}
         )
 
@@ -42,7 +46,7 @@
         {%- endset -%}
 
         to_timestamp(
-            to_unix_timestamp({{from_date_or_timestamp}})
+            {{ spark_utils.assert_not_null('to_unix_timestamp', from_date_or_timestamp) }}
             + {{interval}} * {{multiplier}}
         )
 

--- a/macros/dbt_utils/cross_db_utils/datediff.sql
+++ b/macros/dbt_utils/cross_db_utils/datediff.sql
@@ -1,5 +1,13 @@
 {% macro spark__datediff(first_date, second_date, datepart) %}
 
+    {%- if datepart in ['day', 'week', 'month', 'quarter', 'year'] -%}
+    
+        {# make sure the dates are real, otherwise raise an error asap #}
+        {% set first_date = spark_utils.assert_not_null('date', first_date) %}
+        {% set second_date = spark_utils.assert_not_null('date', second_date) %}
+    
+    {%- endif -%}
+    
     {%- if datepart == 'day' -%}
     
         datediff({{second_date}}, {{first_date}})
@@ -66,12 +74,13 @@
 
         case when {{first_date}} < {{second_date}}
             then ceil((
-                to_unix_timestamp({{second_date}}) 
-                - to_unix_timestamp({{first_date}})
+                {# make sure the timestamps are real, otherwise raise an error asap #}
+                {{ spark_utils.assert_not_null('to_unix_timestamp', second_date) }}
+                - {{ spark_utils.assert_not_null('to_unix_timestamp', first_date) }}
             ) / {{divisor}})
             else floor((
-                to_unix_timestamp({{second_date}}) 
-                - to_unix_timestamp({{first_date}})
+                {{ spark_utils.assert_not_null('to_unix_timestamp', second_date) }}
+                - {{ spark_utils.assert_not_null('to_unix_timestamp', first_date) }}
             ) / {{divisor}})
             end
             

--- a/macros/etc/assert_not_null.sql
+++ b/macros/etc/assert_not_null.sql
@@ -1,0 +1,5 @@
+{% macro assert_not_null(function, arg) %}
+
+    coalesce({{function}}({{arg}}), assert_true({{function}}({{arg}}) is not null))
+
+{% endmacro %}


### PR DESCRIPTION
resolves #6
cc @emilieschario

Use [`assert_true()`](https://spark.apache.org/docs/2.3.0/api/sql/index.html#assert_true) to help Spark give us a more helpful error message, if the user has supplied a date/timestamp that is not real (returns null when cast to date or timestamp).

**models/bad_date_spine.sql**
```sql
{{ dbt_utils.date_spine(
    datepart="day",
    start_date="'2020-02-30'",
    end_date="current_date"
) }}
```

Old error:
```
Compilation Error in model bad_date_spine (models/bad_date_spine.sql)
  '<=' not supported between instances of 'NoneType' and 'int'

  > in macro generate_series (macros/sql/generate_series.sql)
  > called by macro date_spine (macros/datetime/date_spine.sql)
  > called by macro get_powers_of_two (macros/sql/generate_series.sql)
  > called by model bad_dateadd (models/bad_date_spine.sql)
```

New error:
```
Runtime Error in model bad_date_spine (models/bad_date_spine.sql)
  Database Error
    java.lang.RuntimeException: 'isnotnull(cast(2020-02-30 as date))' is not true!
```