### PR TITLE
Bump version number to 0.2.0

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'spark_utils'
-version: '0.2.0'
+version: '0.2.1'
 config-version: 2
 
 require-dbt-version: ">=0.18.0"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'spark_utils'
-version: '0.1.0'
+version: '0.2.0'
 config-version: 2
 
 require-dbt-version: ">=0.18.0"


### PR DESCRIPTION
Spotted this - should this also say 0.2.0 given we're on [the 0.2.0 release](https://github.com/fishtown-analytics/spark-utils/releases/tag/0.2.0)?