### PR TITLE
assert_not_null should skip explicitly NULL fields

### DIFF
--- a/macros/etc/assert_not_null.sql
+++ b/macros/etc/assert_not_null.sql
@@ -1,5 +1,5 @@
 {% macro assert_not_null(function, arg) %}
 
-    coalesce({{function}}({{arg}}), assert_true({{function}}({{arg}}) is not null))
+    coalesce({{function}}({{arg}}), nvl2({{function}}({{arg}}), assert_true({{function}}({{arg}}) is not null), null))
 
 {% endmacro %}


### PR DESCRIPTION
Closes #12. Now the `assert_not_null()` macro should assert only fields that aren't already explicitly NULL 